### PR TITLE
feat: add support for embedded album art in opus files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        sudo apt update && sudo apt install -y ffmpeg
+        sudo apt update && sudo apt install -y ffmpeg opus-tools
         python3 -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Test with tox

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -15,7 +15,8 @@ To run MusicBird you need:
 * A machine running a recent distribution of Linux with enough CPU power to convert music files
 * Python 3.6 or later
 * :code:`pip`
-* :code:`ffmpeg` installed and ready to go
+* :code:`ffmpeg`
+* If you are encoding to Opus and want embedded album art support: :code:`opus-tools`
 
 .. note:: Windows and MacOS are not supported at this time
 
@@ -23,7 +24,7 @@ To install the requirements under Debian/Ubuntu:
 
 .. code::
 
-   sudo apt update && sudo apt install -y ffmpeg python3-pip
+   sudo apt update && sudo apt install -y ffmpeg python3-pip opus-tools
 
 Install
 =======


### PR DESCRIPTION
As of Late 2021, ffmpeg cannot embed the album art from FLAC files
or other sources into Opus files. To offer a workaround, we
now use the official opusenc encoder if available, which
embeds album art just fine.

A warning to users encoding opus files without opusenc will be issued
on every encode run.

FFmpeg ticket for albumart support: https://trac.ffmpeg.org/ticket/4448